### PR TITLE
Support imports of .json files

### DIFF
--- a/ftplugin/jq.vim
+++ b/ftplugin/jq.vim
@@ -17,7 +17,7 @@ set cpoptions&vim
 
 setlocal comments=:#
 setlocal commentstring=#%s
-setlocal suffixesadd=.jq
+setlocal suffixesadd=.jq,.json
 setlocal include=^\\s*\\(import\\\|include\\)
 setlocal define=^\\s*def
 setlocal formatoptions=cqornlj


### PR DESCRIPTION
There is a special import syntax for .json files:

>   import RelativePathString as $NAME [<metadata>];
>       Imports a JSON file found at the given path relative to a directory in a search path. A ".json"  suf-
>       fix will be added to the relative path string. The file's data will be available as $NAME::NAME.