### PR TITLE
Extend ftdetect

### DIFF
--- a/ftdetect/jq.vim
+++ b/ftdetect/jq.vim
@@ -1,2 +1,2 @@
-autocmd BufNewFile,BufRead,StdinReadPost *.jq set filetype=jq
-autocmd BufNewFile,BufRead,StdinReadPost * if getline(1) =~# '^#!\f\+\<jq\>' | set filetype=jq | endif
+autocmd BufNewFile,BufRead,StdinReadPost *.[jxy]q set filetype=jq
+autocmd BufNewFile,BufRead,StdinReadPost * if getline(1) =~# '^#!\f\+\(\s\(-\S\+\)\?\)*\<[jxy]q\>' | set filetype=jq | endif


### PR DESCRIPTION
- Add support for `.yq` and `.xq` file extensions for use with [yq and xq by kislyuk](https://github.com/kislyuk/yq) to process YMAL and XML files with jq scripts
- Allow the use of `/usr/bin/env` in hashband, such as `#!/usr/bin/env jq -f`
- Allow passing arguments to hashbang's `env`, such as `#!/usr/bin/env -S jq -r -f`